### PR TITLE
Fix Modbus packet parsing and expose transaction id

### DIFF
--- a/packet.py
+++ b/packet.py
@@ -116,9 +116,13 @@ class ModbusPacketParser:
             index = struct.unpack(">H", payload[6:8])[0]
             subindex = payload[8]
             length_byte = payload[12]
-            if index != expected_index or subindex != (expected_subindex or subindex):
+            if index != expected_index:
                 raise ModbusException(
-                    f"Response index mismatch: expected 0x{expected_index:04X}/{expected_subindex}, got 0x{index:04X}/{subindex}"
+                    f"Response index mismatch: expected 0x{expected_index:04X}, got 0x{index:04X}"
+                )
+            if expected_subindex is not None and subindex != expected_subindex:
+                raise ModbusException(
+                    f"Response subindex mismatch: expected {expected_subindex}, got {subindex}"
                 )
             if expected_length is not None and length_byte != expected_length:
                 raise ModbusException(

--- a/protocol.py
+++ b/protocol.py
@@ -41,8 +41,7 @@ class DryveSDO:
         for attempt in range(1, self._max_attempts + 1):
             try:
                 pdu = ModbusPacketBuilder.build_read_request(od_key)
-                resp = self.transport.send_request(pdu)
-                tid = self.transport._transaction_id
+                tid, resp = self.transport.send_request(pdu)
                 _, payload = ModbusPacketParser.parse_response(
                     resp,
                     tid,
@@ -76,8 +75,7 @@ class DryveSDO:
         for attempt in range(1, self._max_attempts + 1):
             try:
                 pdu = ModbusPacketBuilder.build_write_request(od_key, value)
-                resp = self.transport.send_request(pdu)
-                tid = self.transport._transaction_id
+                tid, resp = self.transport.send_request(pdu)
                 # для записи payload может быть пустым или содержать подтверждение
                 ModbusPacketParser.parse_response(
                     resp,


### PR DESCRIPTION
## Summary
- fix subindex verification in Modbus response parser
- expose transaction id from `send_request` to avoid races
- update SDO read/write to use returned transaction id
- document new return value and ignore heartbeat responses

## Testing
- `python -m py_compile codec.py exceptions.py od.py packet.py protocol.py transport.py machine.py controller.py state_bits.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848481c09ec832da7e6aa8f18b8cb34