### PR TITLE
Improve drive motion commands

### DIFF
--- a/state_bits.py
+++ b/state_bits.py
@@ -14,6 +14,7 @@ CW_ENABLE_OPERATION    = 0x000F  # биты 0-3 (0b0000_1111)
 CW_DISABLE_VOLTAGE     = 0x0000
 CW_QUICK_STOP          = 0x0002
 CW_FAULT_RESET         = 0x0080  # бит 7
+CW_START_MOTION        = 0x001F  # запуск профилированного перемещения/гоминга
 
 
 # Битовые маски Statusword (0x6041) — стандарт CiA 402


### PR DESCRIPTION
## Summary
- add CW_START_MOTION constant for starting motion commands
- issue start motion command in `move_to_position`
- use the same constant for homing

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68484bae0b00832db79fdc7c70395481