### PR TITLE
Improve drive state detection

### DIFF
--- a/machine.py
+++ b/machine.py
@@ -7,7 +7,7 @@ machine.py — управление state machine dryve D1 (CiA 402)
 import time
 import logging
 
-from exceptions import DryveError, FaultState, OperationTimeout, StateError
+from exceptions import FaultState, OperationTimeout
 from od import ODKey
 from state_bits import (
     DriveState,

--- a/packet.py
+++ b/packet.py
@@ -93,6 +93,8 @@ class ModbusPacketParser:
 
         # MBAP header: TransactionID(2), ProtocolID(2), Length(2), UnitID(1)
         tid, proto, length, unit_id = struct.unpack(">HHHB", response[:7])
+        if proto != 0:
+            raise ModbusException(f"Protocol ID mismatch: {proto}")
         if tid != expected_tid:
             raise TransactionMismatch(f"TID mismatch: expected {expected_tid}, got {tid}")
 

--- a/protocol.py
+++ b/protocol.py
@@ -14,7 +14,7 @@ from exceptions import (
     ModbusException,
 )
 from od import ODKey, OD_MAP, AccessType
-from codec import pack_value, unpack_value
+from codec import unpack_value
 from packet import ModbusPacketBuilder, ModbusPacketParser
 
 
@@ -53,11 +53,11 @@ class DryveSDO:
                 data_bytes = payload[-meta["length"] :]
                 value = unpack_value(data_bytes, meta["dtype"], meta.get("scale", 1))
                 return value
-            except ModbusException as e:
+            except ModbusException:
                 if attempt == self._max_attempts:
                     raise
                 time.sleep(0.1)
-            except DryveError as e:
+            except DryveError:
                 raise
         raise DryveError(f"Failed to read {od_key}")
 
@@ -85,11 +85,11 @@ class DryveSDO:
                     expected_length=None,
                 )
                 return
-            except ModbusException as e:
+            except ModbusException:
                 if attempt == self._max_attempts:
                     raise
                 time.sleep(0.1)
-            except DryveError as e:
+            except DryveError:
                 raise
         raise DryveError(f"Failed to write {od_key}")
 

--- a/state_bits.py
+++ b/state_bits.py
@@ -4,7 +4,7 @@ state_bits.py — константы битов Controlword и Statusword, helpe
 © 2025 Your-Company / MIT-license
 """
 
-from enum import IntEnum, auto
+from enum import IntEnum
 
 
 # Битовые маски Controlword (0x6040) — стандарт CiA 402
@@ -45,25 +45,23 @@ class DriveState(IntEnum):
 
 
 def parse_drive_state(statusword: int) -> DriveState:
-    """
-    Определить состояние CiA 402 по битам statusword.
-    """
-    # https://www.canopen.org/fileadmin/resources/documents/CIA402.pdf
-    if not (statusword & SW_READY_TO_SWITCH_ON):
+    """Map *statusword* bits to a CiA‑402 drive state."""
+    if (statusword & 0x004F) == 0x0000:
         return DriveState.NOT_READY_TO_SWITCH_ON
-    if statusword & SW_SWITCH_ON_DISABLED:
+    if (statusword & 0x006F) == 0x0040:
         return DriveState.SWITCH_ON_DISABLED
-    if (statusword & SW_READY_TO_SWITCH_ON) and not (statusword & SW_SWITCHED_ON):
+    if (statusword & 0x006F) == 0x0021:
         return DriveState.READY_TO_SWITCH_ON
-    if (statusword & SW_SWITCHED_ON) and not (statusword & SW_OPERATION_ENABLED):
+    if (statusword & 0x006F) == 0x0023:
         return DriveState.SWITCHED_ON
-    if statusword & SW_OPERATION_ENABLED:
+    if (statusword & 0x006F) == 0x0027:
         return DriveState.OPERATION_ENABLED
-    if statusword & SW_QUICK_STOP:
+    if (statusword & 0x006F) == 0x0007:
         return DriveState.QUICK_STOP_ACTIVE
-    if statusword & SW_FAULT:
+    if (statusword & 0x004F) == 0x000F:
+        return DriveState.FAULT_REACTION_ACTIVE
+    if (statusword & 0x004F) == 0x0008:
         return DriveState.FAULT
-    # По умолчанию:
     return DriveState.NOT_READY_TO_SWITCH_ON
 
 


### PR DESCRIPTION
## Summary
- improve parse_drive_state logic using CiA‑402 patterns
- validate MBAP protocol ID in packet parser
- remove unused imports and clean up exception handling

## Testing
- `flake8 | head -n 5`
- `python3 -m py_compile $(git ls-files '*.py') && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_684862337548832d91f5c8681185cfe3